### PR TITLE
fix: use `var.repository` instead of repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ No modules.
 |------|------|
 | [github_actions_environment_secret.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_secret.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/actions_secret) | resource |
-| [github_repository.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/data-sources/repository) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,0 @@
-data "github_repository" "this" {
-  full_name = var.repository
-}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "github_actions_secret" "this" {
   for_each = local.secrets
 
-  repository      = data.github_repository.this.name
+  repository      = var.repository
   secret_name     = each.value.name
   plaintext_value = each.value.plaintext
 }
@@ -12,7 +12,7 @@ resource "github_actions_environment_secret" "this" {
     elem.id => elem
   }
 
-  repository      = data.github_repository.this.name
+  repository      = var.repository
   secret_name     = each.value.definition.name
   environment     = each.value.environment
   plaintext_value = each.value.definition.plaintext


### PR DESCRIPTION
The `data.github_repository.name` attribute is only the repository's name, not
the full name of the Github Repository.

Closes #7
