### PR TITLE
fix environment secrets after adding support for encrypted secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,6 @@ resource "github_actions_environment_secret" "this" {
   repository      = var.repository
   secret_name     = each.value.definition.name
   environment     = each.value.environment
-  plaintext_value = lookup(each.value, "plaintext", null)
-  encrypted_value = lookup(each.value, "encrypted", null)
+  plaintext_value = lookup(each.value.definition, "plaintext", null)
+  encrypted_value = lookup(each.value.definition, "encrypted", null)
 }


### PR DESCRIPTION
Support for encrypted secrets were added in d4c454f.

However, in the process, it broke environment secrets because it
changed the value to `lookup(each.value)` instead of
`each.value.definition` since environment secrets has an extra nesting
with the name of the environment as well.

https://github.com/tbobm/terraform-github-secrets/pull/11/commits/d4c454fa95e24c131d12e32ba448c26a22ab29e5#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL18-R20

```diff
-  plaintext_value = each.value.definition.plaintext
+  plaintext_value = lookup(each.value, "plaintext", null)
+  encrypted_value = lookup(each.value, "encrypted", null)
```